### PR TITLE
Upstream upgrade to `0.9.1`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
         python-version: ["3.10", "3.11", "3.12", "pypy3.10"]
+        include:
+          - os: ubuntu-latest
+            python-version: "3.13"
 
     runs-on: ${{ matrix.os }}
     name: ${{ fromJson('{"macos-latest":"macOS","windows-latest":"Windows","ubuntu-latest":"Ubuntu"}')[matrix.os] }} Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12", "pypy3.10"]
-        include:
-          - os: ubuntu-latest
-            python-version: "3.13"
+        python-version: ["3.10", "3.11", "3.12", "3.13", "pypy3.10"]
 
     runs-on: ${{ matrix.os }}
     name: ${{ fromJson('{"macos-latest":"macOS","windows-latest":"Windows","ubuntu-latest":"Ubuntu"}')[matrix.os] }} Python ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.9.1
+
+* Fixed an issue for CPython 3.13 where `ssl.SSLSocket` and `ssl.SSLObject` certificate
+  chain APIs would return different types.
+
 # 0.9.0
 
 * Added support for Python 3.13.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.9.0
+
+* Added support for Python 3.13.
+* Fixed loading additional certificates on macOS.
+* Changed error message for Windows when peer offers no certificates
+  and verification is enabled. Previously was `IndexError`, now is `SSLCertVerificationError`.
+
 # 0.8.0
 
 * Added support for PyPy 3.10 and later.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Truststore **requires Python 3.10 or later** and supports the following platform
 
 ## User Guide
 
+> **Warning**
+> **PLEASE READ:** `inject_into_ssl()` **must not be used by libraries or packages** as it will cause issues on import time when integrated with other libraries.
+> Libraries and packages should instead use `truststore.SSLContext` directly which is detailed below.
+> 
+> The `inject_into_ssl()` function is intended only for use in applications and scripts.
+
 You can inject `truststore` into the standard library `ssl` module so the functionality is used
 by every library by default. To do so use the `truststore.inject_into_ssl()` function:
 
@@ -57,7 +63,7 @@ import requests
 resp = requests.get("https://example.com")
 ```
 
-If you'd like finer-grained control you can create your own `truststore.SSLContext` instance
+If you'd like finer-grained control or you're developing a library or package you can create your own `truststore.SSLContext` instance
 and use it anywhere you'd use an `ssl.SSLContext`:
 
 ```python

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,6 +7,7 @@ urllib3
 requests
 flaky
 httpx
+trustme
 
-# Requires 'cryptography' which doesn't yet support Python 3.13
-trustme; python_version < "3.13"
+# Temporary stop-gap until cffi supports 3.13
+cffi @ https://github.com/python-cffi/cffi/archive/refs/heads/main.zip; python_version > "3.12"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,7 +4,9 @@ pytest
 pytest-asyncio
 pytest-httpserver
 urllib3
-trustme
 requests
 flaky
 httpx
+
+# Requires 'cryptography' which doesn't yet support Python 3.13
+trustme; python_version < "3.13"

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -140,8 +140,9 @@ import truststore
 
 truststore.inject_into_ssl()
 
-http = aiohttp.ClientSession()
-resp = await http.request("GET", "https://example.com")
+async with aiohttp.ClientSession() as http_client:
+    async with http_client.get("https://example.com") as http_response:
+        ...
 ```
 
 If you'd like to use the `truststore.SSLContext` directly you can pass
@@ -154,8 +155,9 @@ import truststore
 
 ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
 
-http = aiohttp.ClientSession(ssl=ctx)
-resp = await http.request("GET", "https://example.com")
+async with aiohttp.ClientSession(ssl=ctx) as http_client:
+    async with http_client.get("https://example.com") as http_response:
+        ...
 ```
 
 ### Using truststore with Requests

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -39,6 +39,12 @@ Truststore **requires Python 3.10 or later** and supports the following platform
 
 ## User Guide
 
+```{warning}
+**PLEASE READ:** `inject_into_ssl()` **must not be used by libraries or packages** as it will cause issues on import time when integrated with other libraries.
+Libraries and packages should instead use `truststore.SSLContext` directly which is detailed below. 
+The `inject_into_ssl()` function is intended only for use in applications and scripts.
+```
+
 You can inject `truststore` into the standard library `ssl` module so the functionality is used
 by every library by default. To do so use the `truststore.inject_into_ssl()` function.
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -12,7 +12,7 @@ SOURCE_FILES = (
 # Run in the current Python environment on CI
 # (where there's a matrix of jobs using different Pythons)
 # but test multiple versions locally
-PYTHONS = None if os.environ.get("CI") else ["3.10", "3.11", "3.12"]
+PYTHONS = None if os.environ.get("CI") else ["3.10", "3.11", "3.12", "3.13"]
 
 
 @nox.session
@@ -32,7 +32,7 @@ def lint(session):
     session.install(
         "black", "isort", "flake8", "mypy", "types-certifi", "tomli", "urllib3"
     )
-    session.run("flake8", "--ignore=E501,W503", *SOURCE_PATHS)
+    session.run("flake8", "--ignore=E501,W503,E704", *SOURCE_PATHS)
     session.run("black", "--check", *SOURCE_PATHS)
     session.run("isort", "--check", "--profile=black", *SOURCE_PATHS)
     session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -29,7 +29,9 @@ def format(session):
 
 @nox.session
 def lint(session):
-    session.install("black", "isort", "flake8", "mypy", "types-certifi", "tomli")
+    session.install(
+        "black", "isort", "flake8", "mypy", "types-certifi", "tomli", "urllib3"
+    )
     session.run("flake8", "--ignore=E501,W503", *SOURCE_PATHS)
     session.run("black", "--check", *SOURCE_PATHS)
     session.run("isort", "--check", "--profile=black", *SOURCE_PATHS)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ filterwarnings = [
   # See: aio-libs/aiohttp#7545
   "ignore:.*datetime.utcfromtimestamp().*:DeprecationWarning",
 ]
+markers = [
+  "internet: test requires Internet access"
+]
 
 [tool.flit.sdist]
 include = ["docs", "tests"]

--- a/src/truststore/__init__.py
+++ b/src/truststore/__init__.py
@@ -10,4 +10,4 @@ from ._api import SSLContext, extract_from_ssl, inject_into_ssl  # noqa: E402
 del _api, _sys  # type: ignore[name-defined] # noqa: F821
 
 __all__ = ["SSLContext", "inject_into_ssl", "extract_from_ssl"]
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/src/truststore/__init__.py
+++ b/src/truststore/__init__.py
@@ -10,4 +10,4 @@ from ._api import SSLContext, extract_from_ssl, inject_into_ssl  # noqa: E402
 del _api, _sys  # type: ignore[name-defined] # noqa: F821
 
 __all__ = ["SSLContext", "inject_into_ssl", "extract_from_ssl"]
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/src/truststore/_api.py
+++ b/src/truststore/_api.py
@@ -49,7 +49,7 @@ def extract_from_ssl() -> None:
     try:
         import urllib3.util.ssl_ as urllib3_ssl
 
-        urllib3_ssl.SSLContext = _original_SSLContext
+        urllib3_ssl.SSLContext = _original_SSLContext  # type: ignore[assignment]
     except ImportError:
         pass
 

--- a/src/truststore/_api.py
+++ b/src/truststore/_api.py
@@ -4,7 +4,7 @@ import socket
 import ssl
 import typing
 
-import _ssl  # type: ignore[import]
+import _ssl  # type: ignore[import-not-found]
 
 from ._ssl_constants import (
     _original_SSLContext,

--- a/src/truststore/_api.py
+++ b/src/truststore/_api.py
@@ -5,6 +5,8 @@ import ssl
 import sys
 import typing
 
+import _ssl  # type: ignore[import-not-found]
+
 from ._ssl_constants import (
     _original_SSLContext,
     _original_super_SSLContext,
@@ -279,10 +281,12 @@ if sys.version_info >= (3, 13):
 
     def _get_unverified_chain_bytes(sslobj: ssl.SSLObject) -> list[bytes]:
         unverified_chain = sslobj.get_unverified_chain() or ()  # type: ignore[attr-defined]
-        return [cert for cert in unverified_chain]
+        return [
+            cert if isinstance(cert, bytes) else cert.public_bytes(_ssl.ENCODING_DER)
+            for cert in unverified_chain
+        ]
 
 else:
-    import _ssl  # type: ignore[import-not-found]
 
     def _get_unverified_chain_bytes(sslobj: ssl.SSLObject) -> list[bytes]:
         unverified_chain = sslobj.get_unverified_chain() or ()  # type: ignore[attr-defined]

--- a/src/truststore/_api.py
+++ b/src/truststore/_api.py
@@ -2,9 +2,8 @@ import os
 import platform
 import socket
 import ssl
+import sys
 import typing
-
-import _ssl  # type: ignore[import-not-found]
 
 from ._ssl_constants import (
     _original_SSLContext,
@@ -171,16 +170,13 @@ class SSLContext(_truststore_SSLContext_super_class):  # type: ignore[misc]
     @typing.overload
     def get_ca_certs(
         self, binary_form: typing.Literal[False] = ...
-    ) -> list[typing.Any]:
-        ...
+    ) -> list[typing.Any]: ...
 
     @typing.overload
-    def get_ca_certs(self, binary_form: typing.Literal[True] = ...) -> list[bytes]:
-        ...
+    def get_ca_certs(self, binary_form: typing.Literal[True] = ...) -> list[bytes]: ...
 
     @typing.overload
-    def get_ca_certs(self, binary_form: bool = ...) -> typing.Any:
-        ...
+    def get_ca_certs(self, binary_form: bool = ...) -> typing.Any: ...
 
     def get_ca_certs(self, binary_form: bool = False) -> list[typing.Any] | list[bytes]:
         raise NotImplementedError()
@@ -276,6 +272,23 @@ class SSLContext(_truststore_SSLContext_super_class):  # type: ignore[misc]
         )
 
 
+# Python 3.13+ makes get_unverified_chain() a public API that only returns DER
+# encoded certificates. We detect whether we need to call public_bytes() for 3.10->3.12
+# Pre-3.13 returned None instead of an empty list from get_unverified_chain()
+if sys.version_info >= (3, 13):
+
+    def _get_unverified_chain_bytes(sslobj: ssl.SSLObject) -> list[bytes]:
+        unverified_chain = sslobj.get_unverified_chain() or ()  # type: ignore[attr-defined]
+        return [cert for cert in unverified_chain]
+
+else:
+    import _ssl  # type: ignore[import-not-found]
+
+    def _get_unverified_chain_bytes(sslobj: ssl.SSLObject) -> list[bytes]:
+        unverified_chain = sslobj.get_unverified_chain() or ()  # type: ignore[attr-defined]
+        return [cert.public_bytes(_ssl.ENCODING_DER) for cert in unverified_chain]
+
+
 def _verify_peercerts(
     sock_or_sslobj: ssl.SSLSocket | ssl.SSLObject, server_hostname: str | None
 ) -> None:
@@ -290,13 +303,7 @@ def _verify_peercerts(
     except AttributeError:
         pass
 
-    # SSLObject.get_unverified_chain() returns 'None'
-    # if the peer sends no certificates. This is common
-    # for the server-side scenario.
-    unverified_chain: typing.Sequence[_ssl.Certificate] = (
-        sslobj.get_unverified_chain() or ()  # type: ignore[attr-defined]
-    )
-    cert_bytes = [cert.public_bytes(_ssl.ENCODING_DER) for cert in unverified_chain]
+    cert_bytes = _get_unverified_chain_bytes(sslobj)
     _verify_peercerts_impl(
         sock_or_sslobj.context, cert_bytes, server_hostname=server_hostname
     )

--- a/src/truststore/_api.py
+++ b/src/truststore/_api.py
@@ -273,7 +273,9 @@ class SSLContext(_truststore_SSLContext_super_class):  # type: ignore[misc]
 
     @verify_mode.setter
     def verify_mode(self, value: ssl.VerifyMode) -> None:
-        super(_original_SSLContext, _original_SSLContext).verify_mode.__set__(self._ctx, value)
+        _original_super_SSLContext.verify_mode.__set__(  # type: ignore[attr-defined]
+            self._ctx, value
+        )
 
 
 # Python 3.13+ makes get_unverified_chain() a public API that only returns DER

--- a/src/truststore/_api.py
+++ b/src/truststore/_api.py
@@ -273,11 +273,7 @@ class SSLContext(_truststore_SSLContext_super_class):  # type: ignore[misc]
 
     @verify_mode.setter
     def verify_mode(self, value: ssl.VerifyMode) -> None:
-        msg = f"{type(self)}:{type(self).__mro__}; {_original_SSLContext}: {_original_SSLContext.__mro__}"
-        raise Exception(msg)
-        _original_super_SSLContext.verify_mode.__set__(  # type: ignore[attr-defined]
-            self._ctx, value
-        )
+        super(_original_SSLContext, _original_SSLContext).verify_mode.__set__(self._ctx, value)
 
 
 # Python 3.13+ makes get_unverified_chain() a public API that only returns DER

--- a/src/truststore/_api.py
+++ b/src/truststore/_api.py
@@ -12,6 +12,7 @@ from ._ssl_constants import (
     _original_super_SSLContext,
     _truststore_SSLContext_dunder_class,
     _truststore_SSLContext_super_class,
+    _verify_mode,
 )
 
 if platform.system() == "Windows":
@@ -273,7 +274,7 @@ class SSLContext(_truststore_SSLContext_super_class):  # type: ignore[misc]
 
     @verify_mode.setter
     def verify_mode(self, value: ssl.VerifyMode) -> None:
-        _original_super_SSLContext.verify_mode.__set__(  # type: ignore[attr-defined]
+        _verify_mode.__set__(  # type: ignore[attr-defined]
             self._ctx, value
         )
 

--- a/src/truststore/_api.py
+++ b/src/truststore/_api.py
@@ -273,6 +273,8 @@ class SSLContext(_truststore_SSLContext_super_class):  # type: ignore[misc]
 
     @verify_mode.setter
     def verify_mode(self, value: ssl.VerifyMode) -> None:
+        msg = f"{type(self)}:{type(self).__mro__}; {_original_SSLContext}: {_original_SSLContext.__mro__}"
+        raise Exception(msg)
         _original_super_SSLContext.verify_mode.__set__(  # type: ignore[attr-defined]
             self._ctx, value
         )

--- a/src/truststore/_api.py
+++ b/src/truststore/_api.py
@@ -3,6 +3,7 @@ import platform
 import socket
 import ssl
 import sys
+import types
 import typing
 
 import _ssl  # type: ignore[import-not-found]
@@ -29,7 +30,7 @@ _StrOrBytesPath: typing.TypeAlias = str | bytes | os.PathLike[str] | os.PathLike
 _PasswordType: typing.TypeAlias = str | bytes | typing.Callable[[], str | bytes]
 
 
-def _override_ssl_class(module):
+def _override_ssl_class(module: types.ModuleType) -> None:
     if cls := getattr(module, "SSLContext"):
         if getattr(cls, "TRUSTSTORE_OVERRIDE", False):
             return

--- a/src/truststore/_api.py
+++ b/src/truststore/_api.py
@@ -12,7 +12,6 @@ from ._ssl_constants import (
     _original_super_SSLContext,
     _truststore_SSLContext_dunder_class,
     _truststore_SSLContext_super_class,
-    _verify_mode,
 )
 
 if platform.system() == "Windows":
@@ -274,7 +273,7 @@ class SSLContext(_truststore_SSLContext_super_class):  # type: ignore[misc]
 
     @verify_mode.setter
     def verify_mode(self, value: ssl.VerifyMode) -> None:
-        _verify_mode.__set__(  # type: ignore[attr-defined]
+        _original_super_SSLContext.verify_mode.__set__(  # type: ignore[attr-defined]
             self._ctx, value
         )
 

--- a/src/truststore/_ssl_constants.py
+++ b/src/truststore/_ssl_constants.py
@@ -1,12 +1,13 @@
 import ssl
 import sys
 import typing
+from _ssl import _SSLContext
 
 # Hold on to the original class so we can create it consistently
 # even if we inject our own SSLContext into the ssl module.
 # SSLContextCopy = type("SSLContextCopy", ssl.SSLContext.__bases__, dict(ssl.SSLContext.__dict__))
 _original_SSLContext = ssl.SSLContext
-_original_super_SSLContext = super(_original_SSLContext, _original_SSLContext)
+_original_super_SSLContext = _SSLContext
 
 # CPython is known to be good, but non-CPython implementations
 # may implement SSLContext differently so to be safe we don't

--- a/src/truststore/_ssl_constants.py
+++ b/src/truststore/_ssl_constants.py
@@ -2,12 +2,11 @@ import ssl
 import sys
 import typing
 
-from _ssl import _SSLContext
-
 # Hold on to the original class so we can create it consistently
 # even if we inject our own SSLContext into the ssl module.
 _original_SSLContext = ssl.SSLContext
-_original_super_SSLContext = super(_SSLContext, _original_SSLContext)
+_original_super_SSLContext = super(_original_SSLContext, _original_SSLContext)
+_verify_mode = _original_super_SSLContext.verify_mode
 
 # CPython is known to be good, but non-CPython implementations
 # may implement SSLContext differently so to be safe we don't

--- a/src/truststore/_ssl_constants.py
+++ b/src/truststore/_ssl_constants.py
@@ -4,9 +4,9 @@ import typing
 
 # Hold on to the original class so we can create it consistently
 # even if we inject our own SSLContext into the ssl module.
-SSLContextCopy = type("SSLContextCopy", (ssl.SSLContext,), dict(ssl.SSLContext.__dict__))
+# SSLContextCopy = type("SSLContextCopy", ssl.SSLContext.__bases__, dict(ssl.SSLContext.__dict__))
 _original_SSLContext = ssl.SSLContext
-_original_super_SSLContext = super(_original_SSLContext, SSLContextCopy)
+_original_super_SSLContext = super(_original_SSLContext, _original_SSLContext)
 
 # CPython is known to be good, but non-CPython implementations
 # may implement SSLContext differently so to be safe we don't

--- a/src/truststore/_ssl_constants.py
+++ b/src/truststore/_ssl_constants.py
@@ -1,13 +1,11 @@
 import ssl
 import sys
 import typing
-from _ssl import _SSLContext
 
 # Hold on to the original class so we can create it consistently
 # even if we inject our own SSLContext into the ssl module.
-# SSLContextCopy = type("SSLContextCopy", ssl.SSLContext.__bases__, dict(ssl.SSLContext.__dict__))
 _original_SSLContext = ssl.SSLContext
-_original_super_SSLContext = _SSLContext
+_original_super_SSLContext = _original_SSLContext.__mro__[1]
 
 # CPython is known to be good, but non-CPython implementations
 # may implement SSLContext differently so to be safe we don't

--- a/src/truststore/_ssl_constants.py
+++ b/src/truststore/_ssl_constants.py
@@ -2,10 +2,12 @@ import ssl
 import sys
 import typing
 
+from _ssl import _SSLContext
+
 # Hold on to the original class so we can create it consistently
 # even if we inject our own SSLContext into the ssl module.
 _original_SSLContext = ssl.SSLContext
-_original_super_SSLContext = super(_original_SSLContext, _original_SSLContext)
+_original_super_SSLContext = super(_SSLContext, _original_SSLContext)
 
 # CPython is known to be good, but non-CPython implementations
 # may implement SSLContext differently so to be safe we don't

--- a/src/truststore/_ssl_constants.py
+++ b/src/truststore/_ssl_constants.py
@@ -4,9 +4,9 @@ import typing
 
 # Hold on to the original class so we can create it consistently
 # even if we inject our own SSLContext into the ssl module.
+SSLContextCopy = type("SSLContextCopy", (ssl.SSLContext,), dict(ssl.SSLContext.__dict__))
 _original_SSLContext = ssl.SSLContext
-_original_super_SSLContext = super(_original_SSLContext, _original_SSLContext)
-_verify_mode = _original_super_SSLContext.verify_mode
+_original_super_SSLContext = super(_original_SSLContext, SSLContextCopy)
 
 # CPython is known to be good, but non-CPython implementations
 # may implement SSLContext differently so to be safe we don't

--- a/src/truststore/_windows.py
+++ b/src/truststore/_windows.py
@@ -375,7 +375,7 @@ def _verify_peercerts_impl(
                 server_hostname,
                 chain_flags=chain_flags,
             )
-        except ssl.SSLCertVerificationError:
+        except ssl.SSLCertVerificationError as e:
             # If that fails but custom CA certs have been added
             # to the SSLContext using load_verify_locations,
             # try verifying using a custom chain engine
@@ -384,15 +384,19 @@ def _verify_peercerts_impl(
                 binary_form=True
             )
             if custom_ca_certs:
-                _verify_using_custom_ca_certs(
-                    ssl_context,
-                    custom_ca_certs,
-                    hIntermediateCertStore,
-                    pCertContext,
-                    pChainPara,
-                    server_hostname,
-                    chain_flags=chain_flags,
-                )
+                try:
+                    _verify_using_custom_ca_certs(
+                        ssl_context,
+                        custom_ca_certs,
+                        hIntermediateCertStore,
+                        pCertContext,
+                        pChainPara,
+                        server_hostname,
+                        chain_flags=chain_flags,
+                    )
+                # Raise the original error, not the new error.
+                except ssl.SSLCertVerificationError:
+                    raise e from None
             else:
                 raise
     finally:

--- a/src/truststore/_windows.py
+++ b/src/truststore/_windows.py
@@ -325,6 +325,12 @@ def _verify_peercerts_impl(
     server_hostname: str | None = None,
 ) -> None:
     """Verify the cert_chain from the server using Windows APIs."""
+
+    # If the peer didn't send any certificates then
+    # we can't do verification. Raise an error.
+    if not cert_chain:
+        raise ssl.SSLCertVerificationError("Peer sent no certificates to verify")
+
     pCertContext = None
     hIntermediateCertStore = CertOpenStore(CERT_STORE_PROV_MEMORY, 0, None, 0, None)
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,18 @@ SUBPROCESS_TIMEOUT = 5
 original_SSLContext = ssl.SSLContext
 
 
-successful_hosts = pytest.mark.parametrize("host", ["example.com", "1.1.1.1"])
+def decorator_requires_internet(decorator):
+    """Mark a decorator with the "internet" mark"""
+
+    def wrapper(f):
+        return pytest.mark.internet(decorator(f))
+
+    return wrapper
+
+
+successful_hosts = decorator_requires_internet(
+    pytest.mark.parametrize("host", ["example.com", "1.1.1.1"])
+)
 
 logger = logging.getLogger("aiohttp.web")
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -20,6 +20,7 @@ from OpenSSL.crypto import X509
 
 import truststore
 from tests import SSLContextAdapter
+from tests.conftest import decorator_requires_internet
 
 pytestmark = pytest.mark.flaky
 
@@ -27,7 +28,10 @@ pytestmark = pytest.mark.flaky
 # if the client drops the connection due to a cert verification error
 socket.setdefaulttimeout(10)
 
-successful_hosts = pytest.mark.parametrize("host", ["example.com", "1.1.1.1"])
+
+successful_hosts = decorator_requires_internet(
+    pytest.mark.parametrize("host", ["example.com", "1.1.1.1"])
+)
 
 
 @dataclass
@@ -118,8 +122,10 @@ failure_hosts_list = [
     ),
 ]
 
-failure_hosts_no_revocation = pytest.mark.parametrize(
-    "failure", failure_hosts_list.copy(), ids=attrgetter("host")
+failure_hosts_no_revocation = decorator_requires_internet(
+    pytest.mark.parametrize(
+        "failure", failure_hosts_list.copy(), ids=attrgetter("host")
+    )
 )
 
 if platform.system() != "Linux":
@@ -139,8 +145,8 @@ if platform.system() != "Linux":
         )
     )
 
-failure_hosts = pytest.mark.parametrize(
-    "failure", failure_hosts_list, ids=attrgetter("host")
+failure_hosts = decorator_requires_internet(
+    pytest.mark.parametrize("failure", failure_hosts_list, ids=attrgetter("host"))
 )
 
 
@@ -318,6 +324,7 @@ def test_trustme_cert_loaded_via_capath(trustme_ca, httpserver):
         assert len(resp.data) > 0
 
 
+@pytest.mark.internet
 def test_trustme_cert_still_uses_system_certs(trustme_ca):
     ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     trustme_ca.configure_trust(ctx)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,10 +13,8 @@ import aiohttp
 import aiohttp.client_exceptions
 import pytest
 import requests
-import trustme
 import urllib3
 import urllib3.exceptions
-from OpenSSL.crypto import X509
 
 import truststore
 from tests import SSLContextAdapter
@@ -152,6 +150,12 @@ failure_hosts = decorator_requires_internet(
 
 @pytest.fixture(scope="session")
 def trustme_ca():
+    # 'trustme' is optional to allow testing on Python 3.13
+    try:
+        import trustme
+    except ImportError:
+        pytest.skip("Test requires 'trustme' to be installed")
+
     ca = trustme.CA()
     yield ca
 
@@ -306,6 +310,8 @@ def test_trustme_cert(trustme_ca, httpserver):
 
 
 def test_trustme_cert_loaded_via_capath(trustme_ca, httpserver):
+    from OpenSSL.crypto import X509
+
     ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     with tempfile.TemporaryDirectory() as capath:
         with open(f"{capath}/cert.pem", "wb") as certfile:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -138,7 +138,10 @@ if platform.system() != "Linux":
                 # "The certificate is revoked.",
                 # TODO: Temporary while certificate is expired on badssl.com.
                 # Test will start failing against once the certificate is fixed.
+                # macOS
                 '"revoked.badssl.com","RapidSSL TLS DV RSA Mixed SHA256 2020 CA-1","DigiCert Global Root CA" certificates do not meet pinning requirements',
+                "“revoked.badssl.com” certificate is expired",
+                # Windows
                 "A required certificate is not within its validity period when verifying against the current system clock or the timestamp in the signed file.",
             ],
         )
@@ -208,6 +211,34 @@ def test_success(host):
 def test_failures(failure):
     with pytest.raises(ssl.SSLCertVerificationError) as e:
         connect_to_host(failure.host)
+
+    error_repr = repr(e.value)
+    assert any(message in error_repr for message in failure.error_messages), error_repr
+
+
+@successful_hosts
+def test_success_after_loading_additional_anchors(host, trustme_ca):
+    with socket.create_connection((host, 443)) as sock:
+        ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+
+        # See if loading additional anchors still uses system anchors.
+        trustme_ca.configure_trust(ctx)
+        with ctx.wrap_socket(sock, server_hostname=host):
+            pass
+
+
+@failure_hosts
+def test_failure_after_loading_additional_anchors(failure, trustme_ca):
+    with (
+        pytest.raises(ssl.SSLCertVerificationError) as e,
+        socket.create_connection((failure.host, 443)) as sock,
+    ):
+        ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+
+        # See if loading additional anchors still fails.
+        trustme_ca.configure_trust(ctx)
+        with ctx.wrap_socket(sock, server_hostname=failure.host):
+            pass
 
     error_repr = repr(e.value)
     assert any(message in error_repr for message in failure.error_messages), error_repr

--- a/tests/test_sslcontext.py
+++ b/tests/test_sslcontext.py
@@ -49,8 +49,9 @@ def test_verify_mode_cert_none():
     assert ctx.check_hostname is False
     assert ctx.verify_mode == ssl.CERT_NONE
 
-    with urllib3.PoolManager(ssl_context=ctx) as http, pytest.warns(
-        InsecureRequestWarning
-    ) as w:
+    with (
+        urllib3.PoolManager(ssl_context=ctx) as http,
+        pytest.warns(InsecureRequestWarning) as w,
+    ):
         http.request("GET", "https://expired.badssl.com/")
     assert len(w) == 1

--- a/tests/test_sslcontext.py
+++ b/tests/test_sslcontext.py
@@ -8,6 +8,7 @@ from urllib3.exceptions import InsecureRequestWarning, SSLError
 import truststore
 
 
+@pytest.mark.internet
 def test_minimum_maximum_version():
     ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     ctx.maximum_version = ssl.TLSVersion.TLSv1_2
@@ -24,6 +25,7 @@ def test_minimum_maximum_version():
     assert ctx.maximum_version == ssl.TLSVersion.TLSv1_2
 
 
+@pytest.mark.internet
 def test_check_hostname_false():
     ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     assert ctx.check_hostname is True
@@ -35,6 +37,7 @@ def test_check_hostname_false():
         assert "match" in str(e.value)
 
 
+@pytest.mark.internet
 def test_verify_mode_cert_none():
     ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     assert ctx.check_hostname is True


### PR DESCRIPTION
This brings in all the upstream changes up to the latest version (**0.9.1**) at the moment of creation of this PR.

Test package:
[robocorp_truststore-0.9.1.tar.gz](https://github.com/user-attachments/files/16095619/robocorp_truststore-0.9.1.tar.gz)